### PR TITLE
Add new `@wkspawn` macro for wrapping mutable `Threads.@spawn` closur…

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          JULIA_NUM_THREADS: 2
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/src/WorkerUtilities.jl
+++ b/src/WorkerUtilities.jl
@@ -359,7 +359,9 @@ macro wkspawn(args...)
         let $(letargs...)
             local task = Task($thunk)
             task.sticky = false
-            ccall(:jl_set_task_threadpoolid, Cint, (Any, Int8), task, $tpid)
+            @static if isdefined(Base.Threads, :maxthreadid)
+                ccall(:jl_set_task_threadpoolid, Cint, (Any, Int8), task, $tpid)
+            end
             if $(Expr(:islocal, var))
                 put!($var, task)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,49 +208,46 @@ using Test, WorkerUtilities
         @test !islocked(rw)
     end
 
-    @testset "@wkspawn" begin
-        # basics
-        @test fetch(@wkspawn(1 + 1)) == 2
-
-        if isdefined(Base.Threads, :maxthreadid)
-            # interactive threadpool
-            @test fetch(@wkspawn(:interactive, 1 + 1)) == 2
-        end
-
-        # show incorrect behavior
-        ref = Ref(10)
-        ansref = Ref(0)
-        wkref = WeakRef(ref)
-        t = let ref=ref
-            Threads.@spawn begin
-                ansref[] = $ref[]
-            end
-        end
-        wait(t)
-        @test ansref[] == 10
-        t = ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
-        # there should be no program references to ref, and 3 GC calls
-        # should have collected it, but it's still alive
-        @test wkref.value.x == 10
-
-        # and now with @wkspawn
-        ref = Ref(10)
-        ansref = Ref(0)
-        wkref = WeakRef(ref)
-        t = let ref=ref
-            @wkspawn begin
-                ansref[] = $ref[]
-            end
-        end
-        wait(t)
-        @test ansref[] == 10
-        t = nothing; ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
-        GC.gc(true); GC.gc(true); GC.gc(true)
-        GC.gc(true); GC.gc(true); GC.gc(true)
-        GC.gc(true); GC.gc(true); GC.gc(true)
-        GC.gc(true); GC.gc(true); GC.gc(true)
-        # correctly GCed
-        @test wkref.value === nothing
-    end
-
 end # @testset "WorkerUtilities"
+
+# running these in a @testset doesn't work for some reason??
+# @testset "@wkspawn" begin
+# basics
+@test fetch(@wkspawn(1 + 1)) == 2
+
+if isdefined(Base.Threads, :maxthreadid)
+    # interactive threadpool
+    @test fetch(@wkspawn(:interactive, 1 + 1)) == 2
+end
+
+# show incorrect behavior
+ref = Ref(10)
+ansref = Ref(0)
+wkref = WeakRef(ref)
+t = let ref=ref
+    Threads.@spawn begin
+        ansref[] = $ref[]
+    end
+end
+wait(t)
+@test ansref[] == 10
+t = nothing; ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
+# there should be no program references to ref, and 3 GC calls
+# should have collected it, but it's still alive
+@test wkref.value.x == 10
+
+# and now with @wkspawn
+ref = Ref(10)
+ansref = Ref(0)
+wkref = WeakRef(ref)
+t = let ref=ref
+    @wkspawn begin
+        ansref[] = $ref[]
+    end
+end
+wait(t)
+@test ansref[] == 10
+t = nothing; ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
+@show wkref
+# correctly GCed
+@test wkref.value === nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,4 +208,45 @@ using Test, WorkerUtilities
         @test !islocked(rw)
     end
 
+    @testset "@wkspawn" begin
+        # basics
+        @test fetch(@wkspawn(1 + 1)) == 2
+
+        if isdefined(Base.Threads, :maxthreadid)
+            # interactive threadpool
+            @test fetch(@wkspawn(:interactive, 1 + 1)) == 2
+        end
+
+        # show incorrect behavior
+        ref = Ref(10)
+        ansref = Ref(0)
+        wkref = WeakRef(ref)
+        t = let ref=ref
+            Threads.@spawn begin
+                ansref[] = $ref[]
+            end
+        end
+        wait(t)
+        @test ansref[] == 10
+        t = ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
+        # there should be no program references to ref, and 3 GC calls
+        # should have collected it, but it's still alive
+        @test wkref.value.x == 10
+
+        # and now with @wkspawn
+        ref = Ref(10)
+        ansref = Ref(0)
+        wkref = WeakRef(ref)
+        t = let ref=ref
+            @wkspawn begin
+                ansref[] = $ref[]
+            end
+        end
+        wait(t)
+        @test ansref[] == 10
+        t = ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
+        # correctly GCed
+        @test wkref.value === nothing
+    end
+
 end # @testset "WorkerUtilities"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,7 +244,7 @@ using Test, WorkerUtilities
         end
         wait(t)
         @test ansref[] == 10
-        t = ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
+        t = nothing; ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
         # correctly GCed
         @test wkref.value === nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,6 +245,10 @@ using Test, WorkerUtilities
         wait(t)
         @test ansref[] == 10
         t = nothing; ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
+        GC.gc(true); GC.gc(true); GC.gc(true)
+        GC.gc(true); GC.gc(true); GC.gc(true)
+        GC.gc(true); GC.gc(true); GC.gc(true)
+        GC.gc(true); GC.gc(true); GC.gc(true)
         # correctly GCed
         @test wkref.value === nothing
     end


### PR DESCRIPTION
…e argumetns in WeakRef

Fixes https://github.com/JuliaData/CSV.jl/issues/1057. Works around current Julia limitation here: https://github.com/JuliaLang/julia/issues/40626.

`@wkspawn` acts just like `Threads.@spawn`, except for mutable, interpolated arguments in the spawned expression, they will also be transparently wrapped as `WeakRef`s, then immediately unwrapped within the spawn block. This avoids the `Task` closure capturing mutable arguments in a more permanent way and preventing their collection later, even after there are no more program references to the mutable argument.