### PR TITLE
Simpler FIFOLock

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
 version = "2.5.0"
 
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 

--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -3,7 +3,7 @@ module ConcurrentUtilities
 import Base: AbstractLock, islocked, trylock, lock, unlock
 export Lockable, OrderedSynchronizer, reset!, ReadWriteLock, readlock, readunlock, @wkspawn,
     Workers, remote_eval, remote_fetch, Worker, terminate!, WorkerTerminatedException,
-    Pool, acquire, release, drain!, try_with_timeout, TimeoutException, FIFOLock
+    Pool, acquire, release, drain!, try_with_timeout, TimeoutException, FIFOLock, SimpleFIFOLock
 
 macro samethreadpool_spawn(expr)
     if VERSION >= v"1.9.2"
@@ -23,6 +23,7 @@ include("rwlock.jl")
 include("pools.jl")
 using .Pools
 include("fifolock.jl")
+include("simplefifolock.jl")
 
 function clear_current_task()
     current_task().storage = nothing

--- a/src/simplefifolock.jl
+++ b/src/simplefifolock.jl
@@ -1,0 +1,124 @@
+mutable struct SimpleFIFOLock <: AbstractLock
+    cond_wait::Base.ThreadSynchronizer
+    reentrancy_count::UInt # 0 iff the lock is not held
+    locked_by::Union{Task,Nothing}  # nothing iff the lock is not held
+    SimpleFIFOLock() = new(Base.ThreadSynchronizer(), 0, nothing)
+end
+
+@inline function Base.trylock(l::SimpleFIFOLock)
+    GC.disable_finalizers(c)
+    ct = current_task()
+    lock(l.cond_wait)
+    locked_by = l.locked_by
+    if locked_by === nothing || locked_by === ct
+        l.rentrancy_count += 1
+        l.locked_by = ct
+        unlock(l.cond_wait)
+        return true
+    end
+    unlock(l.cond_wait)
+    GC.enable_finalizers(c)
+    return false
+end
+
+@inline function Base.lock(l::SimpleFIFOLock)
+    GC.disable_finalizers()
+    ct = current_task()
+    lock(l.cond_wait)
+    locked_by = l.locked_by
+    if locked_by === nothing || locked_by == ct
+        # We unroll the first iteration of the loop to avoid the overyhead of `try-finally`
+        # in the uncontended lock case.
+        l.reentrancy_count += 1
+        l.locked_by = ct
+        unlock(l.cond_wait)
+    else
+        try
+            while l.locked_by !== nothing && l.locked_by !== ct
+                wait(l.cond_wait)
+            end
+            l.reentrancy_count += 1
+            l.locked_by = ct
+        finally
+            unlock(l.cond_wait)
+        end
+    end
+    return nothing
+end
+        
+@inline function Base.unlock(l::SimpleFIFOLock)
+    ct = current_task()
+    lock(l.cond_wait)
+    #@info ":$(@__LINE__()) unlocking" task=current_task() locked_by=l.locked_by count=l.reentrancy_count ql=length(l.cond_wait.waitq)
+    println(@__LINE__())
+    println(@__LINE__())
+    if l.locked_by !== ct
+        @info ":$(@__LINE__())"
+        error("unlock from wrong thread")
+    end
+    if l.reentrancy_count == 0
+        @info ":$(@__LINE__())"
+        error("unlock count must equal lock count")
+    end
+    @info ":$(@__LINE__())"
+    l.reentrancy_count -= 1
+    @info ":$(@__LINE__())"
+    @info ":$(@__LINE__()) now count is" task=current_task() count=l.reentrancy_count
+    if l.reentrancy_count == 0
+        @info "count becomes zero" task=current_task() ql=length(l.cond_wait.waitq)
+        l.locked_by = nothing
+        if !isempty(l.cond_wait.waitq)
+            @info "waitq not empty"  ql=length(l.cond_wait.waitq)
+            t = popfirst!(l.cond_wait.waitq)
+            l.locked_by = t
+            l.reentrancy_count = 1
+            schedule(t)
+        end
+        GC.enable_finalizers()
+    end
+    unlock(l.cond_wait)
+    return nothing
+end
+
+# mutable struct FLock2 <: AbstractLock
+#     lock::ReentrantLock
+#     locked_by::Union{Task,Nothing} # nothing iff the lock is not held
+#     rentrancy_count::UInt          # 0 iff the lock is not held
+#     tasks::Vector{Task}
+#     FLock2() = new(ReentrantLock(), nothing, 0, Task[])
+# end
+
+# @inline function Base.trylock(l::SimpleFIFOLock)
+#     GC.disable_finalizers(c)
+#     ct = current_task()
+#     lock(l.lock)
+#     locked_by = l.locked_by
+#     if locked_by === nothing || locked_by === ct
+#         l.rentrancy_count += 1
+#         l.locked_by = ct
+#         unlock(l.lock)
+#         return true
+#     end
+#     unlock(l.lock)
+#     GC.enable_finalizers(c)
+#     return false
+# end
+
+# @inline function Base.lock(l::SimpleFIFOLock)
+#     GC.disable_finalizers()
+#     ct = current_task()
+#     lock(l.lock)
+#     locked_by = l.locked_by
+#     if locked_by === nothing || locked_by == ct
+#         l.reentrancy_count += 1
+#         l.locked_by = ct
+#         unlock(l.lock)
+#     else
+#         push!(l.tasks, ct)
+#         unlock(l.lock)  # Little race here since someone could sneak in and yield to me.
+#         wait()
+#         l.reentrancy_count += 1
+#         l.locked_by = ct
+#     end
+#     return nothing
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,7 +287,6 @@ else
             for i in 1:16
                 t = Threads.@spawn begin
                     tasks_in[i] = Threads.atomic_add!(ctr_in, 1)
-                    @info "Locking $i"
                     lock(fl)
                     try
                         tot[1] += 1


### PR DESCRIPTION
This PR provides `SimpleFIFOLock`, effectively another implementation of `FIFOLock`.

It's about 1/3 less code, and is simpler: It just uses simple condition-variable programming with no protocol on atomic variables.

On Xeon(R) Platinum 8488C for the following benchmark:
```
@btime begin lock($f); unlock($f); end
```
I see the following performance:
```
13ns for SpinLock
17ns for ReentrantLock
33ns for FIFOLock
35ns for SimpleFIFOLock
```

So it is a little slower than `FIFOLock`, but maybe the extra simplicity makes it preferable.