### PR TITLE
feat: implement `Base.trylock`, subtype `Base.AbstractLock` for `ReadWriteLock`

### DIFF
--- a/src/rwlock.jl
+++ b/src/rwlock.jl
@@ -11,7 +11,7 @@ while the write side is acquired/released via `lock(rw)` and `unlock(rw)`.
 While a writer is active, all readers will block. Once the writer is finished,
 all pending readers will be allowed to acquire/release before the next writer.
 """
-mutable struct ReadWriteLock
+mutable struct ReadWriteLock <: Base.AbstractLock
     writelock::ReentrantLock
     readwait::Threads.Condition
     writeready::Threads.Event

--- a/src/rwlock.jl
+++ b/src/rwlock.jl
@@ -6,7 +6,8 @@
 A threadsafe lock that allows multiple readers or a single writer.
 
 The read side is acquired/released via `readlock(rw)` and `readunlock(rw)`,
-while the write side is acquired/released via `lock(rw)` and `unlock(rw)`.
+while the write side is acquired/released via `lock(rw)`, `trylock(rw)`, and
+`unlock(rw)`.
 Use `readlock(rw) do ... end` or `lock(rw) do ... end` to scope lock
 ownership to a function call.
 
@@ -112,21 +113,17 @@ function Base.lock(rw::ReadWriteLock)
     return
 end
 
-function Base.trylock(rw::ReadWriteLock)
-    success = trylock(rw.writelock)
-    success || return false
+"""
+    trylock(rw::ReadWriteLock)
 
-    r = (@atomic :acquire_release rw.readercount -= MaxReaders) + MaxReaders
-    if r != 0
-        r = (@atomic :acquire_release rw.readercount += MaxReaders)
-        if r > 0
-            # wake up waiting readers
-            Base.@lock rw.readwait notify(rw.readwait)
-        end
-        unlock(rw.writelock)
-        return false
-    end
-    return true
+Attempt to acquire the write side of `rw` without blocking. Return `true` on
+success and `false` if either the read or write side is already held.
+"""
+function Base.trylock(rw::ReadWriteLock)
+    trylock(rw.writelock) || return false
+    result = @atomicreplace :acquire_release :acquire rw.readercount 0 => -MaxReaders
+    result.success || unlock(rw.writelock)
+    return result.success
 end
 
 """
@@ -144,7 +141,14 @@ function Base.lock(f, rw::ReadWriteLock)
     end
 end
 
-Base.islocked(rw::ReadWriteLock) = islocked(rw.writelock)
+"""
+    islocked(rw::ReadWriteLock)
+
+Return `true` if either the read or write side of `rw` is held.
+"""
+function Base.islocked(rw::ReadWriteLock)
+    return islocked(rw.writelock) || (@atomic :monotonic rw.readercount) != 0
+end
 
 function Base.unlock(rw::ReadWriteLock)
     r = (@atomic :acquire_release rw.readercount += MaxReaders)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -111,6 +111,68 @@ using Test, ConcurrentUtilities
         @warn "skipping ReadWriteLock tests since VERSION ($VERSION) < v\"1.8\""
 else
         rw = ReadWriteLock()
+        @test rw isa Base.AbstractLock
+
+        @test trylock(rw)
+        @test islocked(rw)
+        unlock(rw)
+        @test !islocked(rw)
+
+        readlock(rw)
+        @test islocked(rw)
+        @test !trylock(rw)
+        @test trylock(() -> error("unreachable"), rw) === false
+        @test (@atomic rw.readercount) == 1
+        @test (@atomic rw.readerwait) == 0
+        readunlock(rw)
+        @test !islocked(rw)
+
+        try_result = trylock(rw) do
+            @test islocked(rw)
+            :write
+        end
+        @test try_result === :write
+        @test !islocked(rw)
+
+        lock(rw)
+        @test !trylock(rw)
+        @test islocked(rw)
+        unlock(rw)
+        @test !islocked(rw)
+        @test (@atomic rw.readercount) == 0
+        @test (@atomic rw.readerwait) == 0
+
+        if Threads.nthreads() > 1
+            observed_writer_state = Threads.Atomic{Bool}(false)
+            stop_observing = Threads.Atomic{Bool}(false)
+            reader_started = Channel(1)
+            reader = Threads.@spawn begin
+                readlock(rw)
+                put!(reader_started, nothing)
+                while !stop_observing[]
+                    if (@atomic :acquire rw.readercount) < 0
+                        observed_writer_state[] = true
+                    end
+                end
+                readunlock(rw)
+            end
+            take!(reader_started)
+            all_failed = all(!trylock(rw) for _ in 1:100_000)
+            stop_observing[] = true
+            wait(reader)
+            @test all_failed
+            @test !observed_writer_state[]
+            @test (@atomic rw.readerwait) == 0
+        end
+
+        if isdefined(Base, :Lockable)
+            lockable = Base.Lockable(Ref(1), rw)
+            lock(lockable) do value
+                value[] += 1
+            end
+            @test lockable.value[] == 2
+        end
+
         read_result = readlock(rw) do
             @test (@atomic rw.readercount) == 1
             :read
@@ -178,8 +240,7 @@ else
 
         println("test new reads blocked on pending write, and vice versa")
         readlock(rw)
-        # readlock doesn't count as "locked"
-        @test !islocked(rw)
+        @test islocked(rw)
         # start another reader
         secondReaderLocked = Ref(false)
         c = Channel()


### PR DESCRIPTION
## Summary

- make `ReadWriteLock` subtype `Base.AbstractLock`
- implement writer-side `trylock` with an atomic `0 => -MaxReaders` transition
- make `islocked` report either active readers or a writer
- cover generic `trylock(f, lock)`, `Base.Lockable`, and failed-trylock accounting

This preserves @AayushSabharwal's two original commits and adds the current-main
merge plus a focused correctness follow-up.

## Correctness

The original subtract-and-rollback implementation briefly published a negative
`readercount`. A reader unlocking during that window could decrement
`readerwait`, leaving accounting debt after rollback and allowing a later writer
to overlap a live reader.

The follow-up instead acquires the underlying writer lock and atomically replaces
`readercount` only when it is exactly zero. A failed attempt does not change
reader accounting and does not need rollback.

## Validation

- exact `ReadWriteLock` testset:
  - Julia 1.8.5: 53/53
  - Julia 1.11.9: 54/54
  - Julia 1.12.6: 54/54
  - Julia nightly: 55/55
- AllocArrays 1.1.0 downstream suite on Julia 1.11.9: 461/461
- `git diff --check`

Closes #42.

Co-authored by Codex
