### PR TITLE
Prevent concurrency deadlocks and lifecycle leaks

### DIFF
--- a/src/ConcurrentUtilities.jl
+++ b/src/ConcurrentUtilities.jl
@@ -47,9 +47,11 @@ the variable's value in the current task.
 macro wkspawn(args...)
     e = args[end]
     expr = quote
-        ret = $e
-        $(clear_current_task)()
-        ret
+        try
+            $e
+        finally
+            $(clear_current_task)()
+        end
     end
 @static if isdefined(Base.Threads, :maxthreadid)
     q = esc(:(Threads.@spawn $(args[1:end-1]...) $expr))

--- a/src/fifolock.jl
+++ b/src/fifolock.jl
@@ -37,11 +37,10 @@ islocked(l::FIFOLock) = (@atomic :monotonic l.havelock) & LOCKED_BIT != 0
 # safely wait on `cond_wait`.
 #
 # FIFO ordering is ensured in `unlock`, which first acquires
-# the `cond_wait` lock. If `cond_wait`'s wait queue is empty,
-# the lock is released. Otherwise, we pop the first task in
-# the wait queue, transfer ownership to it, schedule it, and
-# return. Thus when one or more tasks are waiting,`havelock`
-# is never reset.
+# the `cond_wait` lock. If `cond_wait` has a waiter, we notify
+# the first one and leave `havelock` set. The notified task then
+# takes ownership before returning from `lock`. Thus when one or
+# more tasks are waiting, `havelock` is never reset.
 
 """
     trylock(l::FIFOLock)
@@ -91,7 +90,9 @@ end
         _trylock(l, ct) && return
         GC.disable_finalizers()
         wait(c)
-        # l.locked_by and l.reentrancy_cnt are set in unlock
+        # unlock leaves havelock set while handing the lock to us.
+        l.reentrancy_cnt = 0x0000_0001
+        @atomic :release l.locked_by = ct
     finally
         unlock(c)
     end
@@ -126,15 +127,10 @@ end
     if n == 0x0000_0000
         lock(c)
         try
-            if isempty(c.waitq)
+            @atomic :release l.locked_by = nothing
+            if notify(c; all=false) == 0
                 l.reentrancy_cnt = n
-                @atomic :release l.locked_by = nothing
                 @atomic :release l.havelock = 0x00
-            else
-                t = popfirst!(c.waitq)
-                @atomic :release l.locked_by = t
-                schedule(t)
-                # Leave l.reentrancy_cnt at 1
             end
         finally
             unlock(c)

--- a/src/fifolock.jl
+++ b/src/fifolock.jl
@@ -89,7 +89,15 @@ end
     try
         _trylock(l, ct) && return
         GC.disable_finalizers()
-        wait(c)
+        try
+            wait(c)
+        catch
+            # cancelled/interrupted before the lock was handed to us; unlock
+            # skips wait entries whose wake was already claimed, so it will
+            # never count us as the new owner
+            GC.enable_finalizers()
+            rethrow()
+        end
         # unlock leaves havelock set while handing the lock to us.
         l.reentrancy_cnt = 0x0000_0001
         @atomic :release l.locked_by = ct

--- a/src/fifolock.jl
+++ b/src/fifolock.jl
@@ -23,7 +23,7 @@ mutable struct FIFOLock <: AbstractLock
     FIFOLock() = new(nothing, 0x0000_0000, 0x00, Base.ThreadSynchronizer())
 end
 
-assert_havelock(l::FIFOLock) = assert_havelock(l, l.locked_by)
+Base.assert_havelock(l::FIFOLock) = Base.assert_havelock(l, l.locked_by)
 islocked(l::FIFOLock) = (@atomic :monotonic l.havelock) & LOCKED_BIT != 0
 
 # Correctness reasoning:

--- a/src/pools.jl
+++ b/src/pools.jl
@@ -145,13 +145,19 @@ function Base.acquire(f, pool::Pool{K, T}, key=nothing; forcenew::Bool=false, is
             wait(pool.lock)
         end
         pool.cur += 1
-        # now see if we can get an object from the pool for reuse
-        if !forcenew
-            objs = iskeyed(pool) ? get!(() -> safesizehint!(T[], pool.limit), pool.keyedvalues, key) : pool.values
-            while !isempty(objs)
-                obj = pop!(objs)
-                isvalid(obj) && return obj
+        try
+            # now see if we can get an object from the pool for reuse
+            if !forcenew
+                objs = iskeyed(pool) ? get!(() -> safesizehint!(T[], pool.limit), pool.keyedvalues, key) : pool.values
+                while !isempty(objs)
+                    obj = pop!(objs)
+                    isvalid(obj) && return obj
+                end
             end
+        catch
+            # validation or pool lookup failed after taking a permit
+            releasepermit(pool)
+            rethrow()
         end
     end
     try

--- a/src/rwlock.jl
+++ b/src/rwlock.jl
@@ -24,32 +24,48 @@ mutable struct ReadWriteLock <: Base.AbstractLock
     # `readercount + MaxReaders` is the number of active or pending readers
     @atomic readercount::Int
     @atomic readerwait::Int
+    @atomic readerepoch::UInt
 end
 
 function ReadWriteLock()
 @static if VERSION < v"1.8"
     throw(ArgumentError("ReadWriteLock requires Julia v1.8 or greater"))
 else
-    return ReadWriteLock(ReentrantLock(), Threads.Condition(), Threads.Event(true), 0, 0)
+    return ReadWriteLock(ReentrantLock(), Threads.Condition(), Threads.Event(true), 0, 0, 0)
 end
 end
 
 const MaxReaders = 1 << 30
 
 function readlock(rw::ReadWriteLock)
+    epoch = @atomic :acquire rw.readerepoch
     # first step is to increment readercount atomically
     if (@atomic :acquire_release rw.readercount += 1) < 0
         # if we observe from our atomic operation that readercount is < 0,
         # a writer was active or pending, so we need initiate the "slowpath"
         # by acquiring the readwait lock
-        Base.@lock rw.readwait begin
-            # check our condition again, if it holds, then we get in line
-            # to be notified once the writer is done (the writer also acquires
-            # the readwait lock, so we'll be waiting until it releases it)
-            if rw.readercount < 0
-                # writer still active
-                wait(rw.readwait)
+        try
+            Base.@lock rw.readwait begin
+                # A later writer can make readercount negative again before a
+                # reader notified by the current writer resumes. The epoch
+                # identifies which writer this reader is waiting behind.
+                while (@atomic :acquire rw.readerepoch) == epoch
+                    wait(rw.readwait)
+                end
             end
+        catch
+            Base.@lock rw.readwait begin
+                if (@atomic :acquire rw.readerepoch) == epoch
+                    # This reader was never released by its writer and was not
+                    # included in that writer's readerwait count.
+                    @atomic :acquire_release rw.readercount -= 1
+                else
+                    # The reader was released, so a later writer may already
+                    # be counting it as an active reader.
+                    readunlock(rw)
+                end
+            end
+            rethrow()
         end
     end
     return
@@ -154,7 +170,10 @@ function Base.unlock(rw::ReadWriteLock)
     r = (@atomic :acquire_release rw.readercount += MaxReaders)
     if r > 0
         # wake up waiting readers
-        Base.@lock rw.readwait notify(rw.readwait)
+        Base.@lock rw.readwait begin
+            @atomic :release rw.readerepoch += 1
+            notify(rw.readwait)
+        end
     end
     unlock(rw.writelock)
     return

--- a/src/rwlock.jl
+++ b/src/rwlock.jl
@@ -24,7 +24,9 @@ mutable struct ReadWriteLock <: Base.AbstractLock
     # `readercount + MaxReaders` is the number of active or pending readers
     @atomic readercount::Int
     @atomic readerwait::Int
-    @atomic readerepoch::UInt
+    # number of pending readers released by a writer's unlock that have not
+    # resumed yet; guarded by the lock of `readwait`
+    readerrelease::Int
 end
 
 function ReadWriteLock()
@@ -38,7 +40,6 @@ end
 const MaxReaders = 1 << 30
 
 function readlock(rw::ReadWriteLock)
-    epoch = @atomic :acquire rw.readerepoch
     # first step is to increment readercount atomically
     if (@atomic :acquire_release rw.readercount += 1) < 0
         # if we observe from our atomic operation that readercount is < 0,
@@ -46,23 +47,36 @@ function readlock(rw::ReadWriteLock)
         # by acquiring the readwait lock
         try
             Base.@lock rw.readwait begin
-                # A later writer can make readercount negative again before a
-                # reader notified by the current writer resumes. The epoch
-                # identifies which writer this reader is waiting behind.
-                while (@atomic :acquire rw.readerepoch) == epoch
+                # An unlocking writer mints one release permit per pending
+                # reader it releases (`readerrelease`); each pending reader
+                # consumes exactly one permit before acquiring the read side.
+                # Permits are fungible: one minted for a slow-to-resume reader
+                # may be consumed by another pending reader, which then stands
+                # in for it in the next writer's `readerwait` count. Counting
+                # permits (rather than re-checking `readercount`, which a
+                # later writer can make negative again) ensures a reader can
+                # neither deadlock behind a writer that already counted it as
+                # active nor slip past a writer that did not release it.
+                while rw.readerrelease == 0
                     wait(rw.readwait)
                 end
+                rw.readerrelease -= 1
             end
         catch
             Base.@lock rw.readwait begin
-                if (@atomic :acquire rw.readerepoch) == epoch
-                    # This reader was never released by its writer and was not
-                    # included in that writer's readerwait count.
-                    @atomic :acquire_release rw.readercount -= 1
-                else
-                    # The reader was released, so a later writer may already
-                    # be counting it as an active reader.
+                if rw.readerrelease > 0
+                    # A writer's unlock already released a pending reader:
+                    # consume one permit as if we briefly held the read side,
+                    # and release it. If the permit was minted for another
+                    # reader, that reader is simply released by a later
+                    # writer's unlock instead (which still counts it).
+                    rw.readerrelease -= 1
                     readunlock(rw)
+                else
+                    # No writer has released us: withdraw our pending reader
+                    # registration. Permits are minted under the readwait lock
+                    # we hold, so no unlocking writer can count us concurrently.
+                    @atomic :acquire_release rw.readercount -= 1
                 end
             end
             rethrow()
@@ -167,11 +181,14 @@ function Base.islocked(rw::ReadWriteLock)
 end
 
 function Base.unlock(rw::ReadWriteLock)
-    r = (@atomic :acquire_release rw.readercount += MaxReaders)
-    if r > 0
-        # wake up waiting readers
-        Base.@lock rw.readwait begin
-            @atomic :release rw.readerepoch += 1
+    # flip the `readercount` sign back under the readwait lock, so that permit
+    # minting is atomic with respect to a cancelled reader withdrawing its
+    # registration (see the catch block in `readlock`)
+    Base.@lock rw.readwait begin
+        r = (@atomic :acquire_release rw.readercount += MaxReaders)
+        if r > 0
+            # mint one release permit per pending reader and wake them up
+            rw.readerrelease += r
             notify(rw.readwait)
         end
     end

--- a/src/spawn.jl
+++ b/src/spawn.jl
@@ -60,7 +60,11 @@ function init(nworkers=Threads.nthreads()-1)
             WORKER_TASKS[tid == 1 ? 1 : (tid - 1)] = Base.@async begin
                 for task in WORK_QUEUE
                     schedule(task)
-                    wait(task)
+                    try
+                        wait(task)
+                    catch e
+                        e isa TaskFailedException || rethrow()
+                    end
                 end
             end
         end
@@ -71,7 +75,11 @@ else
             WORKER_TASKS[tid == 1 ? 1 : (tid - 1)] = Base.@async begin
                 for task in WORK_QUEUE
                     schedule(task)
-                    wait(task)
+                    try
+                        wait(task)
+                    catch e
+                        e isa TaskFailedException || rethrow()
+                    end
                 end
             end
         end

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -244,14 +244,20 @@ function process_responses(w::Worker)
             @assert r isa Response "Received invalid response from worker $(w.pid): $(r)"
             # println("Received response $(r) from worker $(w.pid)")
             Base.@lock lock begin
-                # look up the FutureResult for this request
-                fut = pop!(reqs, r.id)
-                @assert !isready(fut.value) "Received duplicate response for request $(r.id) from worker $(w.pid)"
-                if r.error !== nothing
-                    # this allows rethrowing the exception from the worker to the caller
-                    close(fut.value, r.error)
+                # look up the FutureResult for this request; a concurrent
+                # terminate! may have already closed and removed it, in which
+                # case the response is stale and dropped
+                fut = pop!(reqs, r.id, nothing)
+                if fut === nothing
+                    terminated(w) || error("Received response for unknown request $(r.id) from worker $(w.pid)")
                 else
-                    put!(fut.value, r.result)
+                    @assert !isready(fut.value) "Received duplicate response for request $(r.id) from worker $(w.pid)"
+                    if r.error !== nothing
+                        # this allows rethrowing the exception from the worker to the caller
+                        close(fut.value, r.error)
+                    else
+                        put!(fut.value, r.result)
+                    end
                 end
             end
         end

--- a/src/workers.jl
+++ b/src/workers.jl
@@ -85,6 +85,7 @@ function terminate!(w::Worker, from::Symbol=:manual)
         # we won getting to close down the worker
         @debug "terminating worker $(w.pid) from $from"
         wte = WorkerTerminatedException(w)
+        close(w.workqueue, wte)
         Base.@lock w.lock begin
             for (_, fut) in w.futures
                 close(fut.value, wte)
@@ -128,7 +129,8 @@ function Base.close(w::Worker)
 end
 
 # wait until our spawned tasks have all finished
-Base.wait(w::Worker) = fetch(w.process_watch) && fetch(w.messages) && fetch(w.output)
+Base.wait(w::Worker) =
+    fetch(w.process_watch) && fetch(w.messages) && fetch(w.output) && fetch(w.worksubmission)
 
 Base.show(io::IO, w::Worker) = print(io, "Worker(pid=$(w.pid)", terminated(w) ? ", terminated=true, termsignal=$(w.process.termsignal)" : "", ")")
 
@@ -205,8 +207,12 @@ end
     catch
         # cleanup in case connect fails/times out
         kill(proc, Base.SIGKILL)
-        @isdefined(sock) && close(sock)
-        @isdefined(w) && terminate!(w, :Worker_catch)
+        if @isdefined(w)
+            terminate!(w, :Worker_catch)
+        else
+            @isdefined(pipe) && close(pipe)
+            close(server)
+        end
         rethrow()
     end
 end
@@ -261,16 +267,23 @@ function process_work(w::Worker)
     try
         for (req, fut) in w.workqueue
             # println("Sending request $(req) to worker $(w.pid)")
-            Base.@lock w.lock begin
-                w.futures[req.id] = fut
+            submitted = Base.@lock w.lock begin
+                if terminated(w)
+                    close(fut.value, WorkerTerminatedException(w))
+                    false
+                else
+                    w.futures[req.id] = fut
+                    true
+                end
             end
-            serialize(w.pipe, req)
+            submitted && serialize(w.pipe, req)
         end
     catch e
         # @error "Error processing work for worker $(w.pid)" exception=(e, catch_backtrace())
         terminate!(w, :process_work)
         # e isa EOFError || e isa Base.IOError || rethrow()
     end
+    true
 end
 
 remote_eval(w::Worker, expr) = remote_eval(w, Main, expr.head == :block ? Expr(:toplevel, expr.args...) : expr)

--- a/test/pools.jl
+++ b/test/pools.jl
@@ -81,6 +81,12 @@ using ConcurrentUtilities.Pools, Test
         @test_throws ErrorException acquire(() -> error("oops"), pool; forcenew=true)
         @test Pools.in_use(pool) == 2
 
+        # throwing while validating a pooled object must also return the permit
+        release(pool, x1)
+        @test_throws ErrorException acquire(() -> 7, pool; isvalid=_ -> error("invalid"))
+        @test Pools.in_use(pool) == 1
+        x1 = acquire(() -> 7, pool; forcenew=true)
+
         # we can still acquire a new object
         x3 = acquire(() -> 7, pool; forcenew=true)
         @test x3 == 7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ using Test, ConcurrentUtilities
         @show Threads.nthreads(), threadid
         @test Threads.nthreads() == 1 ? (threadid == 1) : (threadid != 1)
         @test ConcurrentUtilities.@spawn(false, 1 + 1).storage === nothing
+        failed = ConcurrentUtilities.@spawn error("expected failure")
+        @test_throws TaskFailedException wait(failed)
+        @test all(t -> !istaskdone(t), ConcurrentUtilities.WORKER_TASKS)
+        @test fetch(ConcurrentUtilities.@spawn(1 + 1)) == 2
 
     end # @testset "ConcurrentUtilities.@spawn"
 
@@ -314,6 +318,35 @@ else
         put!(wc2, nothing)
         @test fetch(t2)
         @test !islocked(rw)
+
+        # A reader released by one writer must not wait behind the next writer,
+        # since the next writer includes that reader in readerwait.
+        rw = ReadWriteLock()
+        lock(rw)
+        lock(rw.readwait)
+        delayed_reader = @async begin
+            readlock(rw)
+            readunlock(rw)
+            true
+        end
+        while (@atomic rw.readercount) != -ConcurrentUtilities.MaxReaders + 1
+            yield()
+        end
+        unlock(rw)
+        next_writer = @async begin
+            lock(rw)
+            unlock(rw)
+            true
+        end
+        while (@atomic rw.readerwait) != 1
+            yield()
+        end
+        unlock(rw.readwait)
+        @test fetch(delayed_reader)
+        @test fetch(next_writer)
+        @test (@atomic rw.readercount) == 0
+        @test (@atomic rw.readerwait) == 0
+        @test !islocked(rw)
 end # @static if VERSION < v"1.8"
     end
 
@@ -327,6 +360,13 @@ else
         tasks_out = zeros(Int, 16)
         tot = zeros(Int, 1)
         fl = FIFOLock()
+        c = Base.GenericCondition{FIFOLock}(fl)
+        lock(c)
+        try
+            @test notify(c) == 0
+        finally
+            unlock(c)
+        end
         waiters = let fl = fl
             function ()
                 c = fl.cond_wait
@@ -387,6 +427,8 @@ end # @static if VERSION < v"1.10"
         @test Workers.terminated(w)
         @test istaskstarted(w.messages) && istaskdone(w.messages)
         @test istaskstarted(w.output) && istaskdone(w.output)
+        @test istaskstarted(w.worksubmission) && istaskdone(w.worksubmission)
+        @test !isopen(w.workqueue)
         @test isempty(w.futures)
     end
     include("pools.jl")
@@ -433,6 +475,21 @@ end
         t = nothing; ref = nothing; GC.gc(true); GC.gc(true); GC.gc(true)
         @show wkref
         # correctly GCed
+        @test wkref.value === nothing
+
+        # captures are also cleared when the spawned expression fails
+        ref = Ref(10)
+        wkref = WeakRef(ref)
+        t = let ref=ref
+            @wkspawn begin
+                $ref[]
+                error("expected failure")
+            end
+        end
+        @test_throws TaskFailedException wait(t)
+        @test t.code === nothing
+        ref = nothing
+        GC.gc(true); GC.gc(true); GC.gc(true)
         @test wkref.value === nothing
 #     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -367,12 +367,12 @@ else
         finally
             unlock(c)
         end
-        waiters = let fl = fl
+        waitq_tail = let fl = fl
             function ()
                 c = fl.cond_wait
                 lock(c)
                 try
-                    return length(c.waitq)
+                    return c.waitq.tail
                 finally
                     unlock(c)
                 end
@@ -380,6 +380,7 @@ else
         end
         lock(fl)
         try
+            tail = waitq_tail()
             for i in 1:16
                 # Queue each task before starting the next one so the FIFO
                 # assertion tracks lock wait order, not scheduler timing.
@@ -393,9 +394,10 @@ else
                     end
                 end
                 push!(test_tasks, t)
-                while waiters() < i
+                while waitq_tail() === tail
                     yield()
                 end
+                tail = waitq_tail()
             end
         finally
             unlock(fl)
@@ -410,6 +412,25 @@ else
         end
         @test tot[1] == 16
         @test tasks_out == 1:16
+
+@static if isdefined(Base, :CancellationTokenSource)
+        fl = FIFOLock()
+        lock(fl)
+        source = Base.CancellationTokenSource()
+        cancelled = Base.ScopedValues.with(
+            () -> Threads.@spawn(lock(fl)),
+            Base.CANCEL_TOKEN => Base.CancellationToken(source),
+        )
+        while isempty(fl.cond_wait)
+            yield()
+        end
+        Base.cancel!(source)
+        @test timedwait(() -> istaskdone(cancelled), 5) == :ok
+        @test_throws TaskFailedException wait(cancelled)
+        unlock(fl)
+        @test lock(() -> true, fl)
+        @test !islocked(fl)
+end
 end # @static if VERSION < v"1.10"
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -562,6 +562,31 @@ else
         unlock(fl)
         @test lock(() -> true, fl)
         @test !islocked(fl)
+
+        # a task that catches the cancellation and keeps running must not be
+        # left with finalizers disabled
+        lock(fl)
+        source = Base.CancellationTokenSource()
+        survivor = Base.ScopedValues.with(
+            () -> Threads.@spawn(begin
+                try
+                    lock(fl)
+                    false
+                catch
+                    ccall(:jl_gc_get_finalizers_inhibited, Cint, (Ptr{Cvoid},), C_NULL) == 0
+                end
+            end),
+            Base.CANCEL_TOKEN => Base.CancellationToken(source),
+        )
+        while isempty(fl.cond_wait)
+            yield()
+        end
+        Base.cancel!(source)
+        @test timedwait(() -> istaskdone(survivor), 5) == :ok
+        @test fetch(survivor)
+        unlock(fl)
+        @test lock(() -> true, fl)
+        @test !islocked(fl)
 end
 end # @static if VERSION < v"1.10"
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -320,19 +320,84 @@ else
         @test !islocked(rw)
 
         # A reader released by one writer must not wait behind the next writer,
-        # since the next writer includes that reader in readerwait.
+        # since the next writer includes that reader in readerwait. The reader
+        # is descheduled between its readercount increment and its slow path;
+        # we replay its steps deterministically.
         rw = ReadWriteLock()
         lock(rw)
-        lock(rw.readwait)
-        delayed_reader = @async begin
-            readlock(rw)
-            readunlock(rw)
+        @atomic rw.readercount += 1            # reader R increments, then stalls
+        unlock(rw)                             # W1 mints R's release permit
+        next_writer = @async begin
+            lock(rw)
+            unlock(rw)
             true
         end
+        while (@atomic rw.readerwait) != 1     # W2 counts R as an active reader
+            yield()
+        end
+        # R resumes its slow path: it must find the permit and proceed
+        Base.@lock rw.readwait begin
+            @test rw.readerrelease == 1
+            rw.readerrelease -= 1
+        end
+        readunlock(rw)                          # R releases; W2 can proceed
+        @test fetch(next_writer)
+        @test (@atomic rw.readercount) == 0
+        @test (@atomic rw.readerwait) == 0
+        @test rw.readerrelease == 0
+        @test !islocked(rw)
+
+        # A reader that increments while a later writer is active must wait for
+        # that writer even if an earlier writer released other readers in the
+        # meantime (regression: a stale snapshot let it slip past the writer).
+        rw = ReadWriteLock()
+        lock(rw)                                               # W1
+        released = @async (readlock(rw); readunlock(rw); true) # pending behind W1
         while (@atomic rw.readercount) != -ConcurrentUtilities.MaxReaders + 1
             yield()
         end
+        unlock(rw)                                             # W1 releases it
+        @test fetch(released)
+        lock(rw)                                               # W2 active
+        late_reader = @async (readlock(rw); readunlock(rw); true)
+        while (@atomic rw.readercount) != -ConcurrentUtilities.MaxReaders + 1
+            yield()
+        end
+        Base.@lock rw.readwait @test rw.readerrelease == 0     # no leftover permit
+        @test !istaskdone(late_reader)
+        unlock(rw)                                             # W2 releases it
+        @test fetch(late_reader)
+        @test (@atomic rw.readercount) == 0
+        @test !islocked(rw)
+
+        # A pending reader whose slow-path wait throws while its writer still
+        # holds the lock must withdraw its registration.
+        rw = ReadWriteLock()
+        lock(rw)
+        interrupted = @async (readlock(rw); readunlock(rw); true)
+        while (@atomic rw.readercount) != -ConcurrentUtilities.MaxReaders + 1
+            yield()
+        end
+        while isempty(rw.readwait.waitq)
+            yield()
+        end
+        Base.@lock rw.readwait notify(rw.readwait, ErrorException("interrupt"), false, true)
+        @test_throws TaskFailedException wait(interrupted)
+        @test (@atomic rw.readercount) == -ConcurrentUtilities.MaxReaders
         unlock(rw)
+        @test (@atomic rw.readercount) == 0
+        @test rw.readerrelease == 0
+        @test lock(() -> true, rw)
+        @test readlock(() -> true, rw)
+        @test !islocked(rw)
+
+        # A pending reader whose slow-path wait throws after a writer released
+        # it must consume its permit and stand in for the readunlock the next
+        # writer is waiting for (replayed deterministically, as above).
+        rw = ReadWriteLock()
+        lock(rw)
+        @atomic rw.readercount += 1            # reader R increments, then stalls
+        unlock(rw)                             # W1 mints R's release permit
         next_writer = @async begin
             lock(rw)
             unlock(rw)
@@ -341,12 +406,79 @@ else
         while (@atomic rw.readerwait) != 1
             yield()
         end
-        unlock(rw.readwait)
-        @test fetch(delayed_reader)
+        # R's slow path now throws; replay its cleanup
+        Base.@lock rw.readwait begin
+            @test rw.readerrelease == 1
+            rw.readerrelease -= 1
+            readunlock(rw)
+        end
         @test fetch(next_writer)
         @test (@atomic rw.readercount) == 0
         @test (@atomic rw.readerwait) == 0
+        @test rw.readerrelease == 0
         @test !islocked(rw)
+
+        # randomized stress: a writer must never overlap readers or writers
+        rw = ReadWriteLock()
+        active_readers = Threads.Atomic{Int}(0)
+        active_writers = Threads.Atomic{Int}(0)
+        violations = Threads.Atomic{Int}(0)
+        stress_tasks = Task[]
+        for _ in 1:4
+            push!(stress_tasks, Threads.@spawn begin
+                for _ in 1:250
+                    lock(rw)
+                    Threads.atomic_add!(active_writers, 1)
+                    if active_readers[] != 0 || active_writers[] != 1
+                        Threads.atomic_add!(violations, 1)
+                    end
+                    Threads.atomic_sub!(active_writers, 1)
+                    unlock(rw)
+                end
+            end)
+        end
+        for _ in 1:8
+            push!(stress_tasks, Threads.@spawn begin
+                for _ in 1:500
+                    readlock(rw)
+                    Threads.atomic_add!(active_readers, 1)
+                    if active_writers[] != 0
+                        Threads.atomic_add!(violations, 1)
+                    end
+                    Threads.atomic_sub!(active_readers, 1)
+                    readunlock(rw)
+                end
+            end)
+        end
+        foreach(wait, stress_tasks)
+        @test violations[] == 0
+        @test (@atomic rw.readercount) == 0
+        @test (@atomic rw.readerwait) == 0
+        @test rw.readerrelease == 0
+        @test !islocked(rw)
+
+@static if isdefined(Base, :CancellationTokenSource)
+        # real cancellation of a pending reader
+        rw = ReadWriteLock()
+        lock(rw)
+        source = Base.CancellationTokenSource()
+        cancelled = Base.ScopedValues.with(
+            () -> Threads.@spawn(readlock(rw)),
+            Base.CANCEL_TOKEN => Base.CancellationToken(source),
+        )
+        while isempty(rw.readwait.waitq)
+            yield()
+        end
+        Base.cancel!(source)
+        @test timedwait(() -> istaskdone(cancelled), 5) == :ok
+        @test_throws TaskFailedException wait(cancelled)
+        @test (@atomic rw.readercount) == -ConcurrentUtilities.MaxReaders
+        unlock(rw)
+        @test (@atomic rw.readercount) == 0
+        @test lock(() -> true, rw)
+        @test readlock(() -> true, rw)
+        @test !islocked(rw)
+end
 end # @static if VERSION < v"1.8"
     end
 

--- a/test/workers.jl
+++ b/test/workers.jl
@@ -26,6 +26,8 @@ using Test, IOCapture
         @test Workers.terminated(w)
         @test istaskstarted(w.messages) && istaskdone(w.messages)
         @test istaskstarted(w.output) && istaskdone(w.output)
+        @test istaskstarted(w.worksubmission) && istaskdone(w.worksubmission)
+        @test !isopen(w.workqueue)
         @test isempty(w.futures)
     end
 
@@ -39,6 +41,8 @@ using Test, IOCapture
         @test Workers.terminated(w)
         @test istaskstarted(w.messages) && istaskdone(w.messages)
         @test istaskstarted(w.output) && istaskdone(w.output)
+        @test istaskstarted(w.worksubmission) && istaskdone(w.worksubmission)
+        @test !isopen(w.workqueue)
         @test isempty(w.futures)
     end
 
@@ -84,6 +88,8 @@ using Test, IOCapture
         @test Workers.terminated(w)
         @test istaskstarted(w.messages) && istaskdone(w.messages)
         @test istaskstarted(w.output) && istaskdone(w.output)
+        @test istaskstarted(w.worksubmission) && istaskdone(w.worksubmission)
+        @test !isopen(w.workqueue)
         @test isempty(w.futures)
         close(w)
     end
@@ -96,6 +102,21 @@ using Test, IOCapture
         fut = remote_eval(w, :(using Test; @test 1 == 1))
         @test fetch(fut) isa Test.Pass
         close(w)
+    end
+end
+
+@testset "Worker connection failure cleanup" begin
+    if Sys.isunix()
+        mktempdir() do dir
+            withenv("TMPDIR" => dir) do
+                @test_throws ConcurrentUtilities.TimeoutException Worker(
+                    exeflags=`--version`,
+                    connect_timeout=1,
+                    worker_redirect_io=devnull,
+                )
+                @test isempty(readdir(dir))
+            end
+        end
     end
 end
 

--- a/test/workers.jl
+++ b/test/workers.jl
@@ -9,14 +9,9 @@ using Test, IOCapture
         @test process_running(w.process)
         @test isopen(w.pipe)
         @test !Workers.terminated(w)
-        if !(istaskstarted(w.messages) && !istaskdone(w.messages))
-            @show w.messages
-        end
-        @test istaskstarted(w.messages) && !istaskdone(w.messages)
-        if !istaskstarted(w.output)
-            @show w.output
-        end
-        @test istaskstarted(w.output)
+        background_tasks = (w.messages, w.output, w.worksubmission)
+        @test timedwait(() -> all(istaskstarted, background_tasks), 10) == :ok
+        @test all(t -> !istaskdone(t), background_tasks)
         @test isempty(w.futures)
     end
     @testset "clean shutdown ($w)" begin

--- a/test/workers.jl
+++ b/test/workers.jl
@@ -120,6 +120,43 @@ end
     end
 end
 
+@testset "stale response after terminate! does not kill message loop" begin
+    w = Worker(worker_redirect_io=devnull)
+    fut = remote_eval(w, :(sleep(0.2); 1 + 1))
+    while Base.@lock(w.lock, isempty(w.futures))
+        yield()
+    end
+    lock(w.lock)
+    # while we hold the coordinator lock, the worker's response arrives and
+    # the messages task blocks behind us before it can look up the future
+    sleep(1)
+    # simulate a concurrent terminate! winning the race to the futures table
+    wte = WorkerTerminatedException(w)
+    for (_, f) in w.futures
+        close(f.value, wte)
+    end
+    empty!(w.futures)
+@static if VERSION < v"1.7"
+    w.terminated[] = true
+else
+    @atomic w.terminated = true
+end
+    unlock(w.lock)
+    @test_throws WorkerTerminatedException fetch(fut)
+    # finish what terminate! would have done, then wait for a clean shutdown;
+    # the stale response must be dropped rather than kill the messages task
+    close(w.workqueue, wte)
+    kill(w.process, Base.SIGKILL)
+    while !process_exited(w.process)
+        sleep(0.1)
+    end
+    close(w.pipe)
+    close(w.server)
+    @test wait(w)
+    @test istaskstarted(w.messages) && istaskdone(w.messages)
+    @test isempty(w.futures)
+end
+
 @testset "Workers print in color" begin
     project_path = pkgdir(ConcurrentUtilities)
     code = """


### PR DESCRIPTION
## Summary

- prevent `ReadWriteLock` readers from being stranded across consecutive writers without allowing readers to overlap a later writer
- keep the shared `@spawn` worker pool alive when submitted work throws
- restore pool permits when validation throws
- close Worker queues and listener sockets on shutdown and connection failure
- drop stale Worker responses after termination instead of killing the message loop
- clear failed `@wkspawn` captures and repair `FIFOLock` handoff and cancellation cleanup across Julia wait-queue versions

## Root causes

The lock used one condition notification for all writer generations. A reader released by one writer could resume after the next writer had already made the reader count negative. It then waited for the wrong writer even though that writer counted it as active. A first epoch-based correction opened a preemption window where that reader could skip its wait and overlap the next writer. The final design instead mints one counted release permit per pending reader while holding the reader condition lock. Each slow-path reader consumes one permit. Cancellation cleanup either consumes a granted permit and releases the read side, or withdraws an ungranted reader registration.

Several lifecycle paths also assumed successful user work or successful setup. Exceptions could escape a shared worker loop, bypass a pool permit return, retain task captures, or leave a Worker queue or listener open. The cleanup now runs at the resource ownership boundary.

Julia 1.14 nightly changed condition wait queues from raw tasks to cancellation-aware wait entries. `FIFOLock` removed and scheduled those internal nodes directly. It now uses the condition notification API and lets the notified task record ownership before `lock` returns. This preserves FIFO baton handoff and the cancellation wake-claim protocol. An interrupted waiter also restores the task's finalizer-inhibition counter before it exits.

`terminate!` can clear a Worker's futures after a response is already buffered. The response loop previously used an unconditional `pop!`, so that stale response raised `KeyError` and killed the message task. A missing future is now ignored only after termination. Unknown response IDs on a live Worker still fail.

## Validation

- Julia 1.6 full package suite: 194 passed, 1 pre-existing broken
- Julia 1.12 full package suite: 275 passed, 1 pre-existing broken
- exact-head GitHub Actions at `a6d3a15`: Julia 1.6 x64, stable x64, stable x86, and nightly x64 all passed
- Claude Desktop adversarial review with Fable 5 and Extra effort; three review fixes were committed and pushed directly to this branch
- Julia 1.10 randomized concurrency stress: 100 rounds, 4 threads
- Julia 1.12 randomized concurrency stress: 200 rounds, 4 threads
- Julia nightly randomized concurrency stress: 100 rounds, 4 threads
- additional ReadWriteLock mutual-exclusion stress: 60,000 lock cycles on Julia 1.12 and nightly
- additional FIFOLock cancellation stress: 300 rounds with eight waiters on nightly
- additional Worker submit-versus-terminate stress: about 450,000 evaluations on Julia 1.12
- Worker startup readiness probe: 20 constructions each on Julia 1.6 and nightly
- deterministic regression tests cover each fixed path
- all Julia commands used `--startup-file=no`

## Scope note

This does not claim to solve cancellation of a pending `ReadWriteLock` writer. That path needs a revocable writer-registration design because asynchronous task interruption can occur between writer accounting steps.

Co-authored by Codex
